### PR TITLE
Fix config screens ignoring per-instance client certificate and URL

### DIFF
--- a/app/src/main/java/com/github/db1996/taskerha/tasker/base/BaseViewModel.kt
+++ b/app/src/main/java/com/github/db1996/taskerha/tasker/base/BaseViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.withContext
  */
 abstract class BaseViewModel<F : Any, B : Any>(
     initialForm: F,
-    protected val client: HomeAssistantClient? = null
+    protected var client: HomeAssistantClient? = null
 ) : ViewModel(), BaseLogger {
 
     var form by mutableStateOf(initialForm)
@@ -101,6 +101,7 @@ abstract class BaseViewModel<F : Any, B : Any>(
      * @return true if ping succeeded, false otherwise
      */
     protected suspend fun ensureClientReady(): Boolean {
+        val client = this.client
         if (client == null) {
             clientError = "No HomeAssistant client configured"
             logError(clientError)

--- a/app/src/main/java/com/github/db1996/taskerha/tasker/base/BaseViewModelFactory.kt
+++ b/app/src/main/java/com/github/db1996/taskerha/tasker/base/BaseViewModelFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.db1996.taskerha.client.HomeAssistantClient
+import com.github.db1996.taskerha.datamodels.HaInstanceRepository
 import com.github.db1996.taskerha.datamodels.HaSettings
 import com.github.db1996.taskerha.util.HaHttpClientFactory
 import kotlinx.coroutines.CoroutineScope
@@ -70,9 +71,17 @@ abstract class ClientViewModelFactory<VM : ViewModel>(
 ) : BaseViewModelFactory<VM>() {
 
     protected val client: HomeAssistantClient by lazy {
-        val url = HaSettings.loadUrl(context)
-        val token = HaSettings.loadToken(context)
-        HomeAssistantClient(url, token, HaHttpClientFactory.build(context)).also {
+        val instance = HaInstanceRepository.getActive()
+        val url = instance?.resolveUrl() ?: HaSettings.loadUrl(context)
+        val token = instance?.token ?: HaSettings.loadToken(context)
+        val httpClient = HaHttpClientFactory.build(
+            context,
+            clientCertEnabled = instance?.clientCertEnabled
+                ?: HaSettings.loadClientCertEnabled(context),
+            clientCertAlias = instance?.clientCertAlias
+                ?: HaSettings.loadClientCertAlias(context)
+        )
+        HomeAssistantClient(url, token, httpClient).also {
             CoroutineScope(Dispatchers.IO).launch {
                 val success = it.ping()
                 if (!success) {

--- a/app/src/main/java/com/github/db1996/taskerha/tasker/callservice/view/CallServiceViewModel.kt
+++ b/app/src/main/java/com/github/db1996/taskerha/tasker/callservice/view/CallServiceViewModel.kt
@@ -318,6 +318,7 @@ class CallServiceViewModel(
                             if (success) {
                                 services = newClient.getServicesFront()
                                 entities = newClient.getEntities()
+                                client = newClient
                                 clientError = ""
                                 logDebug("Loaded ${services.size} services and ${entities.size} entities from instance: ${instance.name}")
                             } else {

--- a/app/src/main/java/com/github/db1996/taskerha/tasker/getstate/view/HaGetStateViewModel.kt
+++ b/app/src/main/java/com/github/db1996/taskerha/tasker/getstate/view/HaGetStateViewModel.kt
@@ -111,6 +111,7 @@ class HaGetStateViewModel(
                             val success = newClient.ping()
                             if (success) {
                                 entities = newClient.getEntities()
+                                client = newClient
                                 clientError = ""
                                 logDebug("Loaded ${entities.size} entities from instance: ${instance.name}")
                             } else {

--- a/app/src/main/java/com/github/db1996/taskerha/tasker/ontriggerstate/view/OnTriggerStateViewModel.kt
+++ b/app/src/main/java/com/github/db1996/taskerha/tasker/ontriggerstate/view/OnTriggerStateViewModel.kt
@@ -250,6 +250,7 @@ class OnTriggerStateViewModel(
                             val success = newClient.ping()
                             if (success) {
                                 entities = newClient.getEntities()
+                                client = newClient
                                 clientError = ""
                                 logDebug("Loaded ${entities.size} entities from instance: ${instance.name}")
                             } else {


### PR DESCRIPTION
Fixes #16

The config screens' initial `HomeAssistantClient` was built from legacy global settings (remote URL, no per-instance cert), so behind mTLS every registry/entity fetch got a 403 and the entity picker never loaded; actions could then save with an empty `entity_id` and fail at runtime with HTTP 400.

- `ClientViewModelFactory` now builds the initial client from the active instance (`resolveUrl()` + per-instance cert), falling back to legacy settings.
- `BaseViewModel.client` is assignable; `changeInstance()` (CallService/GetState/OnTriggerState) keeps the per-instance client for subsequent operations.

Built the APK and tested on-device against HA behind Cloudflare mTLS: entity list loads and the saved action runs successfully. Developed with AI assistance (Claude); reviewed and validated end-to-end by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)